### PR TITLE
Add portable .NET 4.5 library (profile 259)

### DIFF
--- a/NuGet/CSharpAnalytics.nuspec
+++ b/NuGet/CSharpAnalytics.nuspec
@@ -18,9 +18,6 @@ Custom metrics and dimensions can now be set on a specific activity (recommended
     <tags>google analytics, metrics, analytics, ga, measurement protocol</tags>
   </metadata>
   <files>
-    <file src="..\Binaries\Release\Net45\CSharpAnalytics.Net45.dll" target="lib\net45" />
-    <file src="..\Binaries\Release\Windows8\CSharpAnalytics.Windows8.dll" target="lib\windows8" />
-    <file src="..\Binaries\Release\Windows81\CSharpAnalytics.Windows81.dll" target="lib\windows81" />
-    <file src="..\Binaries\Release\WindowsPhone8\CSharpAnalytics.WindowsPhone8.dll" target="lib\windowsphone8" />
+    <file src="..\Binaries\Release\**\CSharpAnalytics.*.dll" target="lib" />
   </files>
 </package>

--- a/Source/CSharpAnalytics.sln
+++ b/Source/CSharpAnalytics.sln
@@ -50,6 +50,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Portable", "Portable", "{47
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpAnalytics.Portable45", "CSharpAnalytics\CSharpAnalytics.Portable45.csproj", "{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpAnalytics.Sample.Portable", "Samples\CSharpAnalytics.Sample.Portable\CSharpAnalytics.Sample.Portable.csproj", "{82189493-4607-4DB3-90EF-FA886A0DB65D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -362,6 +364,20 @@ Global
 		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Release|x64.ActiveCfg = Release|Any CPU
 		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Release|x86.ActiveCfg = Release|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Release|x64.ActiveCfg = Release|Any CPU
+		{82189493-4607-4DB3-90EF-FA886A0DB65D}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -382,5 +398,6 @@ Global
 		{1A9591AF-E5CD-42DE-80A4-B17B227DD45B} = {6145367D-3F9E-440B-AAE5-2FDF6864C111}
 		{A599EEEA-FC89-47FB-B8A9-DFD16FC3201D} = {3F625E98-D620-4CF3-BD83-5C97B7360496}
 		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6} = {47A079C6-34F7-4D97-9A27-DB288EC01954}
+		{82189493-4607-4DB3-90EF-FA886A0DB65D} = {3F625E98-D620-4CF3-BD83-5C97B7360496}
 	EndGlobalSection
 EndGlobal

--- a/Source/CSharpAnalytics.sln
+++ b/Source/CSharpAnalytics.sln
@@ -46,6 +46,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpAnalytics.Sample.Wind
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpAnalytics.Sample.Wpf", "Samples\CSharpAnalytics.Sample.Wpf\CSharpAnalytics.Sample.Wpf.csproj", "{A599EEEA-FC89-47FB-B8A9-DFD16FC3201D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Portable", "Portable", "{47A079C6-34F7-4D97-9A27-DB288EC01954}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpAnalytics.Portable45", "CSharpAnalytics\CSharpAnalytics.Portable45.csproj", "{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -344,6 +348,20 @@ Global
 		{A599EEEA-FC89-47FB-B8A9-DFD16FC3201D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{A599EEEA-FC89-47FB-B8A9-DFD16FC3201D}.Release|x64.ActiveCfg = Release|Any CPU
 		{A599EEEA-FC89-47FB-B8A9-DFD16FC3201D}.Release|x86.ActiveCfg = Release|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Release|ARM.ActiveCfg = Release|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Release|x64.ActiveCfg = Release|Any CPU
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -363,5 +381,6 @@ Global
 		{2716A467-838A-4553-8FBC-AE29BD83F845} = {6145367D-3F9E-440B-AAE5-2FDF6864C111}
 		{1A9591AF-E5CD-42DE-80A4-B17B227DD45B} = {6145367D-3F9E-440B-AAE5-2FDF6864C111}
 		{A599EEEA-FC89-47FB-B8A9-DFD16FC3201D} = {3F625E98-D620-4CF3-BD83-5C97B7360496}
+		{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6} = {47A079C6-34F7-4D97-9A27-DB288EC01954}
 	EndGlobalSection
 EndGlobal

--- a/Source/CSharpAnalytics/AutoMeasurement/ManualMeasurement.cs
+++ b/Source/CSharpAnalytics/AutoMeasurement/ManualMeasurement.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Attack Pattern LLC.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.Threading.Tasks;
+using CSharpAnalytics.Environment;
+using CSharpAnalytics.Network;
+using CSharpAnalytics.Portable45.Serializers;
+
+namespace CSharpAnalytics
+{
+    public class ManualMeasurement : BaseAutoMeasurement
+    {
+        private readonly Func<bool> isInternetAvailableFunc;
+        private readonly IEnvironment environment;
+        private readonly IEventSerializer eventSerializer;
+
+        public ManualMeasurement(Func<bool> isInternetAvailableFunc, IEnvironment environment = null, IEventSerializer eventSerializer = null)
+        {
+            if (isInternetAvailableFunc == null) throw new ArgumentNullException("isInternetAvailableFunc");
+
+            this.isInternetAvailableFunc = isInternetAvailableFunc;
+            this.environment = environment ?? new ManualEnvironment();
+            this.eventSerializer = eventSerializer;
+        }
+
+        protected override void HookEvents()
+        {
+        }
+
+        protected override void UnhookEvents()
+        {
+        }
+
+        protected override IEnvironment GetEnvironment()
+        {
+            return environment;
+        }
+
+        protected override Task<T> Load<T>(string name)
+        {
+            return eventSerializer != null ? eventSerializer.Load<T>(name) : Task.FromResult(default(T));
+        }
+
+        protected override Task Save<T>(T data, string name)
+        {
+            return eventSerializer != null ? eventSerializer.Save(data, name) : Task.FromResult(0);
+        }
+
+        protected override Task SetupRequesterAsync()
+        {
+            var httpClientRequester = new HttpClientRequester();
+            httpClientRequester.HttpClient.DefaultRequestHeaders.UserAgent.ParseAdd(ClientUserAgent);
+
+            Requester = httpClientRequester.Request;
+
+            return Task.FromResult(true);
+        }
+
+        protected override bool IsInternetAvailable()
+        {
+            return isInternetAvailableFunc();
+        }
+    }
+}

--- a/Source/CSharpAnalytics/CSharpAnalytics.Net45.csproj
+++ b/Source/CSharpAnalytics/CSharpAnalytics.Net45.csproj
@@ -66,6 +66,7 @@
     <Compile Include="AutoMeasurement\WinFormsAutoMeasurement.cs" />
     <Compile Include="AutoMeasurement\WpfAutoMeasurement.cs" />
     <Compile Include="Environment\IEnvironment.cs" />
+    <Compile Include="Environment\ManualEnvironment.cs" />
     <Compile Include="Environment\WinFormsEnvironment.cs" />
     <Compile Include="Environment\WpfEnvironment.cs" />
     <Compile Include="Network\BackgroundUriRequester.cs" />

--- a/Source/CSharpAnalytics/CSharpAnalytics.Portable45.csproj
+++ b/Source/CSharpAnalytics/CSharpAnalytics.Portable45.csproj
@@ -35,7 +35,6 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->
-    <Folder Include="Serializers\" />
     <Folder Include="SystemInfo\" />
   </ItemGroup>
   <ItemGroup>
@@ -53,7 +52,9 @@
     <Compile Include="AutoMeasurement\AutoMeasurement.cs" />
     <Compile Include="AutoMeasurement\BaseAutoMeasurement.cs" />
     <Compile Include="AutoMeasurement\ITrackOwnView.cs" />
+    <Compile Include="AutoMeasurement\ManualMeasurement.cs" />
     <Compile Include="Environment\IEnvironment.cs" />
+    <Compile Include="Environment\ManualEnvironment.cs" />
     <Compile Include="Network\BackgroundUriRequester.cs" />
     <Compile Include="Network\ExtensionMethods.cs" />
     <Compile Include="Network\HttpClientRequester.cs" />
@@ -67,6 +68,7 @@
     <Compile Include="Protocols\Measurement\MeasurementUriBuilder.cs" />
     <Compile Include="Debugging\ParameterDefinition.cs" />
     <Compile Include="Debugging\ProtocolDebugger.cs" />
+    <Compile Include="Serializers\IEventSerializer.cs" />
     <Compile Include="Sessions\SessionManager.cs" />
     <Compile Include="Sessions\SessionState.cs" />
     <Compile Include="Sessions\TimeoutSessionManager.cs" />

--- a/Source/CSharpAnalytics/CSharpAnalytics.Portable45.csproj
+++ b/Source/CSharpAnalytics/CSharpAnalytics.Portable45.csproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{345A8A61-8B6B-4EF0-A041-A573A6FF2AD6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CSharpAnalytics.Portable45</RootNamespace>
+    <AssemblyName>CSharpAnalytics.Portable45</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <OutputPath>..\..\Binaries\Debug\Portable45\</OutputPath>
+    <IntermediateOutputPath>obj\Debug\Portable45\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+    <Folder Include="Serializers\" />
+    <Folder Include="SystemInfo\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Activities\AutoTimedEventActivity.cs" />
+    <Compile Include="Activities\ContentViewActivity.cs" />
+    <Compile Include="Activities\ExceptionActivity.cs" />
+    <Compile Include="Activities\EventActivity.cs" />
+    <Compile Include="Activities\MeasurementActivity.cs" />
+    <Compile Include="Activities\ScreenViewActivity.cs" />
+    <Compile Include="Activities\TimedEventActivity.cs" />
+    <Compile Include="Activities\TransactionItemActivity.cs" />
+    <Compile Include="Activities\SocialActivity.cs" />
+    <Compile Include="Activities\TransactionActivity.cs" />
+    <Compile Include="AutoMeasurement\AnalyticsScreenNameAttribute.cs" />
+    <Compile Include="AutoMeasurement\AutoMeasurement.cs" />
+    <Compile Include="AutoMeasurement\BaseAutoMeasurement.cs" />
+    <Compile Include="AutoMeasurement\ITrackOwnView.cs" />
+    <Compile Include="Environment\IEnvironment.cs" />
+    <Compile Include="Network\BackgroundUriRequester.cs" />
+    <Compile Include="Network\ExtensionMethods.cs" />
+    <Compile Include="Network\HttpClientRequester.cs" />
+    <Compile Include="Protocols\Measurement\MeasurementTracker.cs" />
+    <Compile Include="Protocols\Measurement\MeasurementActivityParameterBuilder.cs" />
+    <Compile Include="Protocols\Measurement\MeasurementAnalyticsClient.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Protocols\KeyValuePair.cs" />
+    <Compile Include="Protocols\Measurement\MeasurementConfiguration.cs" />
+    <Compile Include="Debugging\MeasurementParameterDefinitions.cs" />
+    <Compile Include="Protocols\Measurement\MeasurementUriBuilder.cs" />
+    <Compile Include="Debugging\ParameterDefinition.cs" />
+    <Compile Include="Debugging\ProtocolDebugger.cs" />
+    <Compile Include="Sessions\SessionManager.cs" />
+    <Compile Include="Sessions\SessionState.cs" />
+    <Compile Include="Sessions\TimeoutSessionManager.cs" />
+    <Compile Include="Sessions\Visitor.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/CSharpAnalytics/Environment/ManualEnvironment.cs
+++ b/Source/CSharpAnalytics/Environment/ManualEnvironment.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Attack Pattern LLC.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+namespace CSharpAnalytics.Environment
+{
+    public class ManualEnvironment : IEnvironment
+    {
+        public ManualEnvironment()
+        {
+        }
+
+        public ManualEnvironment(string characterSet, string languageCode, string flashVersion, bool? javaEnabled,
+            uint screenColorDepth, uint screenHeight, uint screenWidth, uint viewportHeight, uint viewportWidth)
+        {
+            CharacterSet = characterSet;
+            LanguageCode = languageCode;
+            FlashVersion = flashVersion;
+            JavaEnabled = javaEnabled;
+            ScreenColorDepth = screenColorDepth;
+            ScreenHeight = screenHeight;
+            ScreenWidth = screenWidth;
+            ViewportHeight = viewportHeight;
+            ViewportWidth = viewportWidth;
+        }
+
+        public string CharacterSet { get; set; }
+        public string LanguageCode { get; set; }
+        public string FlashVersion { get; set; }
+        public bool? JavaEnabled { get; set; }
+        public uint ScreenColorDepth { get; set; }
+        public uint ScreenHeight { get; set; }
+        public uint ScreenWidth { get; set; }
+        public uint ViewportHeight { get; set; }
+        public uint ViewportWidth { get; set; }
+    }
+}

--- a/Source/CSharpAnalytics/Protocols/Measurement/MeasurementUriBuilder.cs
+++ b/Source/CSharpAnalytics/Protocols/Measurement/MeasurementUriBuilder.cs
@@ -123,7 +123,10 @@ namespace CSharpAnalytics.Protocols.Measurement
         /// <returns>Enumerable of key/value pairs containing parameters for this environment.</returns>
         internal static IEnumerable<KeyValuePair<string, string>> GetParameters(IEnvironment environment)
         {
-            yield return KeyValuePair.Create("ul", environment.LanguageCode.ToLowerInvariant());
+            yield return
+                KeyValuePair.Create("ul",
+                    environment.LanguageCode != null ? environment.LanguageCode.ToLowerInvariant() : null);
+
             yield return KeyValuePair.Create("de", environment.CharacterSet == null ? "-" : environment.CharacterSet.ToUpperInvariant());
 
             if (!String.IsNullOrWhiteSpace(environment.FlashVersion))

--- a/Source/CSharpAnalytics/Serializers/IEventSerializer.cs
+++ b/Source/CSharpAnalytics/Serializers/IEventSerializer.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Attack Pattern LLC.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Threading.Tasks;
+
+namespace CSharpAnalytics.Portable45.Serializers
+{
+    public interface IEventSerializer
+    {
+        Task<T> Load<T>(string name);
+        Task Save<T>(T data, string name);
+    }
+}

--- a/Source/Samples/CSharpAnalytics.Sample.Portable/App.config
+++ b/Source/Samples/CSharpAnalytics.Sample.Portable/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/Source/Samples/CSharpAnalytics.Sample.Portable/CSharpAnalytics.Sample.Portable.csproj
+++ b/Source/Samples/CSharpAnalytics.Sample.Portable/CSharpAnalytics.Sample.Portable.csproj
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{82189493-4607-4DB3-90EF-FA886A0DB65D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CSharpAnalytics.Sample.Portable</RootNamespace>
+    <AssemblyName>CSharpAnalytics.Sample.Portable</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CSharpAnalytics\CSharpAnalytics.Portable45.csproj">
+      <Project>{345a8a61-8b6b-4ef0-a041-a573a6ff2ad6}</Project>
+      <Name>CSharpAnalytics.Portable45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/Samples/CSharpAnalytics.Sample.Portable/Program.cs
+++ b/Source/Samples/CSharpAnalytics.Sample.Portable/Program.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace CSharpAnalytics.Sample.Portable
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var m = new ManualMeasurement(() => true);
+            m.DebugWriter = Console.WriteLine;
+            m.Start(new MeasurementConfiguration("UA-319000-8", "console app", "1.0"), "run");
+
+            Console.WriteLine("Sample app using portable library");
+            while (true)
+            {
+                Console.WriteLine("[s] to track screen");
+                Console.WriteLine("[e] to track event");
+                Console.WriteLine("[q] to quit");
+                ConsoleKeyInfo key = Console.ReadKey(true);
+                switch (key.KeyChar)
+                {
+                    case 's':
+                        m.Client.TrackScreenView("My Text Screen");
+                        break;
+                    case 'e':
+                        m.Client.TrackEvent("My Action", "My Custom Category", "My Label");
+                        break;
+                    case 'q':
+                        return;
+                }
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/Source/Samples/CSharpAnalytics.Sample.Portable/Properties/AssemblyInfo.cs
+++ b/Source/Samples/CSharpAnalytics.Sample.Portable/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CSharpAnalytics.Sample.Portable")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CSharpAnalytics.Sample.Portable")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2e39dcad-a054-4b58-b3a5-a03db25ba567")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Profile 259 supports .NET 4.5 + Windows 8 + Win Phone 8.1 + Win Phone + Silverlight 8.
This is a very wide and popular profile, also supported by Xamarin for Android and iOS. Google Analytics already has SDKs for those platforms, so I'm not sure how relevant they are for this project.

Added a console app to demonstrate how it can be used without any application frameworks like WPF, winforms and Windows store.

I'm not sure if I've approached this the right way, adding a ManualMeasurement class with platform-agnostic implementations for environment and system info and injecting an optional serializer by interface. It would be good to get some feedback on it.