### PR TITLE
Not relying on exception for program flow

### DIFF
--- a/Source/CSharpAnalytics/Serializers/AppDataContractSerializer.cs
+++ b/Source/CSharpAnalytics/Serializers/AppDataContractSerializer.cs
@@ -10,7 +10,7 @@ namespace CSharpAnalytics.Serializers
     /// Provides an easy way to serialize and deserialize simple classes to a user AppData folder in
     /// Windows Forms applications.
     /// </summary>
-    internal static class AppDataContractSerializer
+    public static class AppDataContractSerializer
     {
         private static string folderPath;
 

--- a/Source/CSharpAnalytics/Serializers/AppDataContractSerializer.cs
+++ b/Source/CSharpAnalytics/Serializers/AppDataContractSerializer.cs
@@ -52,6 +52,10 @@ namespace CSharpAnalytics.Serializers
             try
             {
                 var file = GetFilePath<T>(filename);
+                if (!File.Exists(file))
+                {
+                    return default(T);
+                }
 
                 try
                 {


### PR DESCRIPTION
If I run our application with the library and would like to catch all
exceptions not only those unhandled; then the Restore method will always
throw an exception (if there id no file). With this change it will check
if it exists and then return the default if it didnt exist. There is no
need to try to read the stream from the file because it will not be
there.
