### PR TITLE
Add event time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ $RECYCLE.BIN/
 # Roslyn VS2015 junk
 *.sln.ide/
 *.nupkg
+
+# Visual Studio temp and user data 
+*/.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ $RECYCLE.BIN/
 
 # Roslyn VS2015 junk
 *.sln.ide/
+*.nupkg

--- a/NuGet/CSharpAnalytics.nuspec
+++ b/NuGet/CSharpAnalytics.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Sonova.CSharpAnalytics</id>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <authors>Damien Guard</authors>
     <owners>Attack Pattern</owners>
     <licenseUrl>https://raw.githubusercontent.com/sonova/CSharpAnalytics/master/Source/LICENCE.txt</licenseUrl>

--- a/NuGet/CSharpAnalytics.nuspec
+++ b/NuGet/CSharpAnalytics.nuspec
@@ -1,26 +1,22 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>CSharpAnalytics</id>
-    <version>1.2.1</version>
+    <id>Sonova.CSharpAnalytics</id>
+    <version>1.3.0</version>
     <authors>Damien Guard</authors>
     <owners>Attack Pattern</owners>
-    <licenseUrl>https://raw.github.com/AttackPattern/CSharpAnalytics/master/Source/LICENCE.txt</licenseUrl>
-    <projectUrl>https://github.com/AttackPattern/CSharpAnalytics</projectUrl>
+    <licenseUrl>https://raw.githubusercontent.com/sonova/CSharpAnalytics/master/Source/LICENCE.txt</licenseUrl>
+    <projectUrl>https://github.com/sonova/CSharpAnalytics</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Google Analytics client for C# applications with automatic wire-up for Windows 8/8.1 store applications.</description>
-    <releaseNotes>Stop some phantom sessions by not sending queue time (qt) with session control (sc)
-Detect Windows OS version in store apps even on machines with a custom HAL
-Save session id and session number at startup to avoid loss should the app crash
-Custom metrics and dimensions can now be set on a specific activity (recommended)
+    <releaseNotes>
+	1st Sonova release based on CSharpAnalytics 1.2.1
+	Fix for issue #47 - session start and session end time stamps registered at GA are very often too late relative to other events	
     </releaseNotes>
     <copyright>Copyright 2012-2015 Attack Pattern LLC</copyright>
     <tags>google analytics, metrics, analytics, ga, measurement protocol</tags>
   </metadata>
   <files>
     <file src="..\Binaries\Release\Net45\CSharpAnalytics.Net45.dll" target="lib\net45" />
-    <file src="..\Binaries\Release\Windows8\CSharpAnalytics.Windows8.dll" target="lib\windows8" />
-    <file src="..\Binaries\Release\Windows81\CSharpAnalytics.Windows81.dll" target="lib\windows81" />
-    <file src="..\Binaries\Release\WindowsPhone8\CSharpAnalytics.WindowsPhone8.dll" target="lib\windowsphone8" />
   </files>
 </package>

--- a/NuGet/package.bat
+++ b/NuGet/package.bat
@@ -1,0 +1,1 @@
+nuget pack CSharpAnalytics.nuspec

--- a/Source/CSharpAnalytics.Tests/Properties/AssemblyInfo.cs
+++ b/Source/CSharpAnalytics.Tests/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Resources;
 [assembly: AssemblyProduct("CSharpAnalytics")]
 [assembly: AssemblyCopyright("Copyright © 2012-2014 Attack Pattern LLC.")]
 
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]
 [assembly: AssemblyDescriptionAttribute("Unit tests for CSharpAnalytics")]
 [assembly: NeutralResourcesLanguageAttribute("")]

--- a/Source/CSharpAnalytics.Tests/Properties/AssemblyInfo.cs
+++ b/Source/CSharpAnalytics.Tests/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Resources;
 [assembly: AssemblyProduct("CSharpAnalytics")]
 [assembly: AssemblyCopyright("Copyright © 2012-2014 Attack Pattern LLC.")]
 
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]
 [assembly: AssemblyDescriptionAttribute("Unit tests for CSharpAnalytics")]
 [assembly: NeutralResourcesLanguageAttribute("")]

--- a/Source/CSharpAnalytics.Tests/Properties/AssemblyInfo.cs
+++ b/Source/CSharpAnalytics.Tests/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Resources;
 [assembly: AssemblyProduct("CSharpAnalytics")]
 [assembly: AssemblyCopyright("Copyright © 2012-2014 Attack Pattern LLC.")]
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]
 [assembly: AssemblyDescriptionAttribute("Unit tests for CSharpAnalytics")]
 [assembly: NeutralResourcesLanguageAttribute("")]

--- a/Source/CSharpAnalytics.Tests/Protocols/Measurement/MeasurementAnalyticsClientTests.cs
+++ b/Source/CSharpAnalytics.Tests/Protocols/Measurement/MeasurementAnalyticsClientTests.cs
@@ -115,13 +115,14 @@ namespace CSharpAnalytics.Test.Protocols.Measurement
         }
 
         [TestMethod]
-        public void MeasurementAnalyticsClient_AdjustUriBeforeRequest_Adds_Qt_Parameter()
+        public void MeasurementAnalyticsClient_AdjustUriBeforeRequest_Adds_TimeStamp_Parameters()
         {
             var originalUri = new Uri("http://anything.really.com/something#" + DateTime.UtcNow.ToString("o"));
 
             var actual = new MeasurementAnalyticsClient().AdjustUriBeforeRequest(originalUri);
 
             StringAssert.Contains(actual.Query, "qt=");
+            StringAssert.Contains(actual.Query, "et=");
         }
 
         [TestMethod]

--- a/Source/CSharpAnalytics.Tests/Protocols/Measurement/MeasurementAnalyticsClientTests.cs
+++ b/Source/CSharpAnalytics.Tests/Protocols/Measurement/MeasurementAnalyticsClientTests.cs
@@ -125,16 +125,6 @@ namespace CSharpAnalytics.Test.Protocols.Measurement
         }
 
         [TestMethod]
-        public void MeasurementAnalyticsClient_AdjustUriBeforeRequest_Does_Not_Add_Qt_Parameter_If_Sc_Parameter_Present()
-        {
-            var originalUri = new Uri("http://anything.really.com/something?sc=start#" + DateTime.UtcNow.ToString("o"));
-
-            var actual = new MeasurementAnalyticsClient().AdjustUriBeforeRequest(originalUri);
-
-            Assert.IsFalse(actual.Query.Contains("qt="));
-        }
-
-        [TestMethod]
         public void MeasurementAnalyticsClient_AdjustUriBeforeRequest_Clears_Fragment()
         {
             var originalUri = new Uri("http://anything.really.com/something#" + DateTime.UtcNow.ToString("o"));

--- a/Source/CSharpAnalytics.Tests/Protocols/Measurement/MeasurementUriBuilderTests.cs
+++ b/Source/CSharpAnalytics.Tests/Protocols/Measurement/MeasurementUriBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using CSharpAnalytics.Activities;
 using CSharpAnalytics.Protocols.Measurement;
 using CSharpAnalytics.Test.Environment;
@@ -93,6 +94,22 @@ namespace CSharpAnalytics.Test.Protocols.Measurement
 
             Assert.AreEqual("https", actual.Scheme);
             Assert.AreEqual("ssl.google-analytics.com", actual.Host);
+        }
+
+
+        [TestMethod]
+        public void MeasurementUriBuilderTests_TrackingEndpointOverride_IsUsed_DontCare_UseSsl()
+        {
+            var config = MeasurementTestHelpers.Configuration;
+            config.UseSsl = false;
+            var trackingEnpointOverride = new Uri("https://www.sonova-ga-analytics.com/collect");
+            config.TrackingEndpointOverride = trackingEnpointOverride;
+            var builder = new MeasurementUriBuilder(config, MeasurementTestHelpers.CreateSessionManager(), MeasurementTestHelpers.CreateEnvironment());
+
+            var actual = builder.BuildUri(new ScreenViewActivity("Home"));
+
+            Assert.AreEqual(trackingEnpointOverride.Host, actual.Host);
+            Assert.AreEqual(trackingEnpointOverride.Scheme, actual.Scheme);
         }
 
         [TestMethod]

--- a/Source/CSharpAnalytics/AutoMeasurement/BaseAutoMeasurement.cs
+++ b/Source/CSharpAnalytics/AutoMeasurement/BaseAutoMeasurement.cs
@@ -57,7 +57,7 @@ namespace CSharpAnalytics
         /// <param name="configuration">Configuration to use, must at a minimum specify your Google Analytics ID and app name.</param>
         /// <param name="launchKind">Kind of launch this application experienced.</param>
         /// <param name="uploadInterval">How often to upload to the server. Lower times = more traffic but realtime. Defaults to 5 seconds.</param>
-        /// <example>var analyticsTask = AutoMeasurement.StartAsync(new MeasurementConfiguration("UA-123123123-1", "MyApp", "1.2.0.0"));</example>
+        /// <example>var analyticsTask = AutoMeasurement.StartAsync(new MeasurementConfiguration("UA-123123123-1", "MyApp", "1.3.0.0"));</example>
         public async void Start(MeasurementConfiguration configuration, string launchKind, TimeSpan? uploadInterval = null)
         {
             if (!isStarted)

--- a/Source/CSharpAnalytics/Properties/AssemblyInfo.cs
+++ b/Source/CSharpAnalytics/Properties/AssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("CSharpAnalytics")]
 [assembly: AssemblyCopyright("Copyright © 2012-2014 Attack Pattern LLC.")]
 
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]
 [assembly: ComVisible(false)]
 
 [assembly: InternalsVisibleTo("CSharpAnalytics.Test.Net45")]

--- a/Source/CSharpAnalytics/Properties/AssemblyInfo.cs
+++ b/Source/CSharpAnalytics/Properties/AssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("CSharpAnalytics")]
 [assembly: AssemblyCopyright("Copyright © 2012-2014 Attack Pattern LLC.")]
 
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]
 [assembly: ComVisible(false)]
 
 [assembly: InternalsVisibleTo("CSharpAnalytics.Test.Net45")]

--- a/Source/CSharpAnalytics/Properties/AssemblyInfo.cs
+++ b/Source/CSharpAnalytics/Properties/AssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("CSharpAnalytics")]
 [assembly: AssemblyCopyright("Copyright © 2012-2014 Attack Pattern LLC.")]
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]
 [assembly: ComVisible(false)]
 
 [assembly: InternalsVisibleTo("CSharpAnalytics.Test.Net45")]

--- a/Source/CSharpAnalytics/Protocols/Measurement/MeasurementAnalyticsClient.cs
+++ b/Source/CSharpAnalytics/Protocols/Measurement/MeasurementAnalyticsClient.cs
@@ -269,6 +269,9 @@ namespace CSharpAnalytics.Protocols.Measurement
             DateTime utcHitTime;
             if (!DateTime.TryParse(decodedFragment, out utcHitTime)) return;
 
+            //Event Time "et": add non measurement protocol parameter, can be used by a server side dispatcher to re-adjust "qt" 
+            parameters["et"] = utcHitTime.ToString("O");
+
             var queueTime = DateTimeOffset.Now.Subtract(utcHitTime);
             if (queueTime.TotalMilliseconds < 0) return;
 

--- a/Source/CSharpAnalytics/Protocols/Measurement/MeasurementAnalyticsClient.cs
+++ b/Source/CSharpAnalytics/Protocols/Measurement/MeasurementAnalyticsClient.cs
@@ -263,7 +263,7 @@ namespace CSharpAnalytics.Protocols.Measurement
         /// <param name="parameters">URI parameters to add the relative QT parameter to.</param>
         private static void AddQueueTimeFromFragment(Uri uri, IDictionary<string, string> parameters)
         {
-            if (String.IsNullOrWhiteSpace(uri.Fragment) || parameters.ContainsKey("sc")) return;
+            if (String.IsNullOrWhiteSpace(uri.Fragment)) return;
             var decodedFragment = uri.GetComponents(UriComponents.Fragment, UriFormat.Unescaped);
 
             DateTime utcHitTime;

--- a/Source/CSharpAnalytics/Protocols/Measurement/MeasurementConfiguration.cs
+++ b/Source/CSharpAnalytics/Protocols/Measurement/MeasurementConfiguration.cs
@@ -47,6 +47,12 @@ namespace CSharpAnalytics
         public bool UseSsl { get; set; }
 
         /// <summary>
+        /// If set (not null) then tracking will go to this url instead of going to the original google url.
+        /// In this case UseSsl has no effect.
+        /// </summary>
+        public Uri TrackingEndpointOverride { get; set; }
+
+        /// <summary>
         /// Sample rate percentage to determine how likely new visitors will be tracked.
         /// </summary>
         /// <remarks>

--- a/Source/CSharpAnalytics/Protocols/Measurement/MeasurementUriBuilder.cs
+++ b/Source/CSharpAnalytics/Protocols/Measurement/MeasurementUriBuilder.cs
@@ -52,7 +52,10 @@ namespace CSharpAnalytics.Protocols.Measurement
         {
             var parameters = BuildParameterList(activity);
             CarryForwardParameters(activity, parameters);
-            var endpoint = configuration.UseSsl ? secureTrackingEndpoint : trackingEndpoint;
+
+            var endpoint = configuration.TrackingEndpointOverride != null
+                ? configuration.TrackingEndpointOverride
+                : (configuration.UseSsl ? secureTrackingEndpoint : trackingEndpoint);
 
             // Fragment is only added temporarily and used to calculate queue time.
             // It will be removed in MeasurementAnalyticsClient.AdjustUriBeforeRequest.

--- a/Source/Samples/CSharpAnalytics.Sample.WinForms/Properties/AssemblyInfo.cs
+++ b/Source/Samples/CSharpAnalytics.Sample.WinForms/Properties/AssemblyInfo.cs
@@ -7,6 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("CSharpAnalytics")]
 [assembly: AssemblyCopyright("Copyright © 2012-2014 Attack Pattern LLC.")]
 
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]
 [assembly: ComVisible(false)]

--- a/Source/Samples/CSharpAnalytics.Sample.WinForms/Properties/AssemblyInfo.cs
+++ b/Source/Samples/CSharpAnalytics.Sample.WinForms/Properties/AssemblyInfo.cs
@@ -7,6 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("CSharpAnalytics")]
 [assembly: AssemblyCopyright("Copyright © 2012-2014 Attack Pattern LLC.")]
 
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]
 [assembly: ComVisible(false)]

--- a/Source/Samples/CSharpAnalytics.Sample.WinForms/Properties/AssemblyInfo.cs
+++ b/Source/Samples/CSharpAnalytics.Sample.WinForms/Properties/AssemblyInfo.cs
@@ -7,6 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("CSharpAnalytics")]
 [assembly: AssemblyCopyright("Copyright © 2012-2014 Attack Pattern LLC.")]
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
Event Time "et": add non measurement protocol parameter, can be used by a server side dispatcher to re-adjust "qt". "et" itselve will be ignored by Google.